### PR TITLE
Flush stdout when needed

### DIFF
--- a/mcrcon.c
+++ b/mcrcon.c
@@ -557,6 +557,8 @@ void packet_print(rc_packet *packet)
 
 	// print newline if string has no newline
 	if (packet->data[i-1] != 10 && packet->data[i-1] != 13) putchar('\n');
+
+	fflush(stdout);
 }
 
 rc_packet *packet_build(int id, int cmd, char *s1)
@@ -654,6 +656,7 @@ int run_terminal_mode(int sock)
 
 	while (global_connection_alive) {
 		putchar('>');
+		fflush(stdout);
 		int len = get_line(command, DATA_BUFFSIZE);
 
 		if ((strcasecmp(command, "exit") && strcasecmp(command, "quit")) == 0)


### PR DESCRIPTION
This fixes a bug on certain machines (eg the iSH emulator on iOS), where the output of commands and/or the prompt wouldn't be printed correctly.

Before:
```
Kabirs-iPhone:~# mcrcon -H <HOST> -p <PASS>
Logged in. Type 'quit' or 'exit' to quit.
say hi
list
>>There are 0 of a max 20 players online: 
^C>Kabirs-iPhone:~#
```

After:
```
Kabirs-iPhone:~# mcrcon -H <HOST> -p <PASS>
Logged in. Type 'quit' or 'exit' to quit.
>say hi
>list
There are 0 of a max 20 players online: 
>^CKabirs-iPhone:~# 
```