### PR TITLE
Fixed compiler error

### DIFF
--- a/mcrcon.c
+++ b/mcrcon.c
@@ -573,7 +573,7 @@ rc_packet *packet_build(int id, int cmd, char *s1)
 	packet.size = sizeof(int) * 2 + s1_len + 2;
 	packet.id = id;
 	packet.cmd = cmd;
-	strncpy(packet.data, s1, DATA_BUFFSIZE);
+	strncpy(packet.data, s1, DATA_BUFFSIZE - 1);
 
 	return &packet;
 }


### PR DESCRIPTION
This fixes the compiler error that is thrown when compiling with: `gcc -std=gnu11 -pedantic -Wall -Wextra -O2 -s -o mcrcon mcrcon.c`.

This would never have been an issue, because of the check on line 568, but the compiler still complains. This will make it happy.

```
mcrcon.c: In function ‘packet_build’:
mcrcon.c:576:2: warning: ‘strncpy’ specified bound 4096 equals destination size [-Wstringop-truncation]
  strncpy(packet.data, s1, DATA_BUFFSIZE);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```