### PR TITLE
Added readline support for linux/osx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ EXENAME = mcrcon
 PREFIX ?= /usr/local
 
 INSTALL = install
-LINKER =
+LINKER = -lreadline
 RM = rm -v -f
 
 CC = gcc
-CFLAGS = -std=gnu99 -Wall -Wextra -Wpedantic -Os -s
-EXTRAFLAGS ?= -fstack-protector-strong
+CFLAGS = -std=gnu99 -Wall -Wextra -Wpedantic -Os -s 
+EXTRAFLAGS ?= -fstack-protector-strong 
 
 ifeq ($(OS), Windows_NT)
 	LINKER = -lws2_32


### PR DESCRIPTION
Added support for readline to provide command history and smoother terminal handling.  I could not find a reasonable version for windows, nor do I have a windows dev environment so I created a stub version for _WIN32 using the existing get_line function as a base with tweaks as readline returns malloc'd memory.